### PR TITLE
Pseudo response

### DIFF
--- a/src/main/protobuf/game.proto
+++ b/src/main/protobuf/game.proto
@@ -21,7 +21,7 @@ message SubscribeRequest {
   string game_id = 1;
   string name = 2;
   string type = 3; // ie. PLAYER, OBSERVER TODO: See if there are enums
-  int32 postion = 4; // Optional, raises an exception if type = OBSERVER. If not supplied default to next open position.
+  int32 position = 4; // Optional, raises an exception if type = OBSERVER. If not supplied default to next open position.
 }
 
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -4,6 +4,6 @@
 akka {
 
   # options: OFF, ERROR, WARNING, INFO, DEBUG
-  loglevel = "DEBUG"
+  loglevel = "INFO"
 
 }

--- a/src/main/scala/server/CatanServer.scala
+++ b/src/main/scala/server/CatanServer.scala
@@ -6,7 +6,7 @@ import akka.actor.typed.ActorSystem
 import io.grpc.{Server, ServerBuilder}
 import io.grpc.stub.StreamObserver
 import soc.akka.{MoveResultProvider, RandomMoveResultProvider}
-import soc.game.{GameRules, RollDiceMove}
+import soc.game.{GameRules, RollDiceMove, CatanMove}
 import soc.game.board.{BaseBoardConfiguration, BaseCatanBoard}
 import soc.game.inventory.Inventory.{NoInfo, PerfectInfo}
 import soc.playerRepository.{PlayerContext, PlayerRepository}
@@ -116,15 +116,19 @@ private class CatanServerImpl extends CatanServerGrpc.CatanServer {
 
   override def move(req: MoveRequest) = this.synchronized  {
     val playerContext = games.get(req.gameId).flatMap(_.getPlayer(req.position)).getOrElse(throw new Exception(""))
-    val move = playerContext.getLastRequestRandomMove(req.gameId, req.position)
+    val move = if(req.action == "") playerContext.getLastRequestRandomMove(req.gameId, req.position) else translate(req.action)
     val result = playerContext.receiveMove(req.gameId, req.position, move)
     Future.successful(new MoveResponse(if (result) "SUCCESS" else "ERROR"))
   }
 
-  // TODO: Add methods for registerPlayer, setBoard, setState
-  // ie. The pattern should be to create a game, then configure the game how you want, then start.
-  // Note: We can create defaults so not every step has to be called every time
-  // Further, we can create parameterization on the CreateGameRequest, start=Boolean.
-  // This could allow a client to create and start a game with one call.
+  // TODO: Move this method somewhere generic
+  // Instead of taking a string, this should take an object defined in the gRPC schema
+  /**
+   * Takes a move object from the gRPC layer and translates it into a CatanMove object
+   **/
+  def translate(action: String): CatanMove = {
+      // TODO: Implement
+      return null
 
+  }
 }

--- a/src/main/scala/soc/akka/GameBehavior.scala
+++ b/src/main/scala/soc/akka/GameBehavior.scala
@@ -55,8 +55,6 @@ object GameBehavior {
     context.log.info(s"Starting Game ${config.gameId.key}")
     playerRefs.foreach{ case (pos, p) => p ! StartGame(config.gameId, config.initStates.playerStates(pos)) }
 
-
-    println("HERE")
     // Send first request for first player's initial placement
     context.ask[RequestMessage[GAME, PLAYERS], MoveResponse](playerRefs(firstPlayerId)) { ref =>
       InitialPlacementRequest(config.gameId,
@@ -109,8 +107,7 @@ object GameBehavior {
         val winMsg = s"Player ${winner.get.position} has won game ${config.gameId} with ${winner.get.points} points and ${states.gameState.diceRolls} rolls ${states.gameState.players.getPlayers.map(p => (p.position, p.points))}"
         context.log.info(winMsg)
         context.log.debug(s"${winner.get}")
-        val update = GameUpdate(payload = "GAME OVER: " + winMsg, actionRequestedPlayers = Seq.empty[String])
-        //subscribers.values.foreach(subscriber => subscriber.onNext(update))
+        playerRefs.values.foreach(_ ! GameOver(config.gameId, winMsg))
         Behaviors.stopped
 
       case StateMessage(states, MoveResponse(player, move)) =>

--- a/src/main/scala/soc/akka/PlayerBehavior.scala
+++ b/src/main/scala/soc/akka/PlayerBehavior.scala
@@ -22,6 +22,10 @@ object PlayerBehavior {
           playerContext.sendInitialGameState(gameId, position, state)
           Behaviors.same
 
+        case GameOver(gameId, msg) =>
+          playerContext.sendGameOver(gameId, position, msg)
+          Behaviors.stopped
+
         case MoveResultUpdate(gameId, result) =>
           playerContext.updateGameState(gameId, position, result)
           Behaviors.same

--- a/src/main/scala/soc/akka/messages/UpdateMessage.scala
+++ b/src/main/scala/soc/akka/messages/UpdateMessage.scala
@@ -16,6 +16,7 @@ sealed trait DevelopmentCardUpdate extends UpdateMessage
 
 object UpdateMessage {
   case class StartGame[PLAYER <: Inventory[PLAYER]](gameId: GameId, state: GameState[PLAYER]) extends UpdateMessage
+  case class GameOver(gameId: GameId, msg: String) extends UpdateMessage
   case class TurnUpdate(gameId: GameId, playerId: Int, turnNumber: Int = 0) extends UpdateMessage
 
   case class MoveResultUpdate(gameId: GameId, moveResult: MoveResult) extends UpdateMessage

--- a/src/main/scala/soc/game/player/moveSelector/MoveSelector.scala
+++ b/src/main/scala/soc/game/player/moveSelector/MoveSelector.scala
@@ -10,12 +10,12 @@ import scala.concurrent.Future
 
 trait MoveSelector[GAME <: Inventory[GAME], PLAYER <: Inventory[PLAYER]] {
 
-  def initialPlacementMove(gameState: GameState[PLAYER], inventory: GAME, position: Int)(first: Boolean): Future[CatanMove]
+  def initialPlacementMove(gameState: GameState[PLAYER], inventory: GAME, position: Int)(first: Boolean): CatanMove
 
-  def discardCardsMove(gameState: GameState[PLAYER],inventory: GAME, position: Int): Future[CatanMove]
+  def discardCardsMove(gameState: GameState[PLAYER],inventory: GAME, position: Int): CatanMove
 
-  def moveRobberAndStealMove(gameState: GameState[PLAYER],inventory: GAME, position: Int): Future[CatanMove]
+  def moveRobberAndStealMove(gameState: GameState[PLAYER],inventory: GAME, position: Int): CatanMove
 
-  def turnMove(gameState: GameState[PLAYER],inventory: GAME, position: Int): Future[CatanMove]
+  def turnMove(gameState: GameState[PLAYER],inventory: GAME, position: Int): CatanMove
 
 }

--- a/src/main/scala/soc/game/player/moveSelector/PossibleMoveSelector.scala
+++ b/src/main/scala/soc/game/player/moveSelector/PossibleMoveSelector.scala
@@ -10,25 +10,25 @@ import scala.util.Random
 
 case class PossibleMoveSelector[T <: Inventory[T]](select: (GameState[T], Iterator[CatanMove]) => CatanMove) extends MoveSelector[PerfectInfo, T] {
 
-  override def initialPlacementMove(gameState: GameState[T], inventory: PerfectInfo, position: Int)(first: Boolean): Future[CatanMove] = {
+  override def initialPlacementMove(gameState: GameState[T], inventory: PerfectInfo, position: Int)(first: Boolean): CatanMove = {
     val moves = CatanPossibleMoves(gameState, inventory, position).getPossibleInitialPlacements(first).toIterator
-    Future.successful(select(gameState, moves))
+    select(gameState, moves)
   }
 
-  override def discardCardsMove(gameState: GameState[T], inventory: PerfectInfo, position: Int): Future[CatanMove] = {
+  override def discardCardsMove(gameState: GameState[T], inventory: PerfectInfo, position: Int): CatanMove = {
     val moves = CatanPossibleMoves(gameState, inventory, position).getPossibleDiscards().toIterator
-    Future.successful(select(gameState, moves))
+    select(gameState, moves)
   }
 
-  override def moveRobberAndStealMove(gameState: GameState[T], inventory: PerfectInfo, position: Int): Future[CatanMove] = {
+  override def moveRobberAndStealMove(gameState: GameState[T], inventory: PerfectInfo, position: Int): CatanMove = {
     val moves = CatanPossibleMoves(gameState, inventory, position).getPossibleRobberLocations.toIterator
-    Future.successful(select(gameState, moves))
+    select(gameState, moves)
 
   }
 
-  override def turnMove(gameState: GameState[T], inventory: PerfectInfo, position: Int): Future[CatanMove] = {
+  override def turnMove(gameState: GameState[T], inventory: PerfectInfo, position: Int): CatanMove = {
     val moves =  CatanPossibleMoves(gameState, inventory, position).getPossibleMovesForState.toIterator
-    Future.successful(select(gameState, moves))
+    select(gameState, moves)
   }
 }
 

--- a/src/main/scala/soc/playerRepository/PlayerContext.scala
+++ b/src/main/scala/soc/playerRepository/PlayerContext.scala
@@ -59,11 +59,7 @@ class PlayerContext[GAME <: Inventory[GAME], PLAYER <: Inventory[PLAYER]](val na
 
   def receiveMove(gameId: String, position: Int, move: CatanMove): Boolean = {
     expectedResponses.get((gameId, position)).map(_.success(move))
-    val p = expectedResponses.remove((gameId, position))
-    p match {
-      case Some(p) => true
-      case None => false
-    }
+    expectedResponses.remove((gameId, position)).isDefined
   }
 
   def getLastRequestRandomMove(gameId: String, position: Int): CatanMove = this.synchronized {


### PR DESCRIPTION
## What
Allows the client to response with an empty string in rather than an action.

In this case, the `PlayerContext` will just use the state from when the request was made to make a random move. Puts a framework in place so if a client *does* respond, the server will interpret that response and pass it along as a `CatanMove` to the player context.