### PR TITLE
Proto definitions

### DIFF
--- a/src/main/protobuf/game.proto
+++ b/src/main/protobuf/game.proto
@@ -30,7 +30,7 @@ message GameMessage {
 /**
  * GameMessage targeted at a specific player, telling that player a specific action is requested.
  **/
-message ActionRequest {
+ message ActionRequest {
   int32 position = 1;
   enum ActionRequestType {
     ACKNOWLEDGE_PING = 0;
@@ -40,8 +40,9 @@ message ActionRequest {
     BUILD_OR_TRADE_OR_PLAY_OR_PASS = 4;
     MOVE_ROBBER = 5;
     DISCARD = 6;
-    ACCEPT_OR_REJECT_TRADE = 7;
-    ACKNOWLEDGE_TRADE = 8;
+    EVALUATE_TRADE = 7;
+    COUNTER_OR_ACKNOWLEDGE_TRADE = 8;
+    PROPOSE_TRADE_OR_PASS = 9;
   }
   ActionRequestType type = 2;
   // TODO: This object should probably also contian the game state
@@ -74,8 +75,6 @@ enum GameAction {
   REJECT_TRADE = 15;
   DISCARD = 16;
   END_TURN = 17;
-  // Should we have a seperate way of acknowleding game start vs akcnowledging a trade vs acknowleding a ping?
-  // Should we add another rpc call for acknowledge other than TakeAction?
   ACKNOWLEDGE = 18; 
 }
 
@@ -94,7 +93,7 @@ enum GameAction {
  * GameEvent {
  *   position: 2
  *   action: MOVE_ROBBER_AND_STEAL,
- *   specification: {hex: B4, other_player_position: 1},
+ *   specification: {hex: B4, other_player_positions: [1]},
  *   result: {card: HiddenCard{ viewable_by_positions: [1, 2], encrypted_name: "askdgi4858fjmcd39932"}},
  *   message: null
  * }
@@ -139,37 +138,16 @@ message GameEvent {
  * Of note, like the GameAction enum, the ActionSpecification object used in the TaekAction RPC
  * is directly piped through into the GameEvent response.
  * The GameEvent response might optionally also inlcude a result.
- * For more inforamtion see GameEvent.
  * Depending on the action being taken, different combinations of the below fields will be specified.
- * See mapping below:
- * GAME_ACTION_NONE --> No Action Spec
- * INITIAL_PLACEMENT --> vertex, edge
- * ROLL_DICE --> No Action Spec
- * MOVE_ROBBER_AND_STEAL --> hex, other_player (optional)
- * BUILD_ROAD --> edge
- * BUILD_SETTLEMENT --> vertex
- * BUILD_CITY --> vertex
- * BUILD_DEVELOPMENT_CARD --> No Action Spec
- * ACTIVATE_KNIGHT --> hex, other_player
- * ACTIVATE_ROAD_BUILDING --> edges OR edge
- * ACTIVATE_YEAR_OF_PLENTY --> ask
- * ACTIVATE_MONOPOLY --> ask
- * PROPOSE_TRADE --> ask, give
- * PORT_TRADE --> ask, give
- * ACCEPT_TRADE --> ask, give
- * REJECT_TRADE --> ask, give
- * DISCARD --> give
- * END_TURN --> No Action Spec
- * ACKNOWLEDGE --> No Action Spec
+ * For more inforamtion see GameEvent.
  **/
 message ActionSpecification {
-  string hex = 2;
-  string vertex = 3;
-  Edge edge = 4;
-  repeated Edge edges = 5; // Road Building
-  int32 other_player_position = 7; // Trade, Steal
-  repeated Resource ask = 8; // Trade, Monopoly, Year of Plenty
-  repeated Resource give = 9; // Trade, Discard
+  string hex = 1; // Robber
+  string vertex = 2; // Build City / Settelemnt
+  repeated Edge edges = 3; // Build Road, Road Building
+  repeated int32 other_player_positions = 4; // Trade, Robber
+  repeated Resource ask = 5; // Trade, Monopoly, Year of Plenty
+  repeated Resource give = 6; // Trade, Discard
 }
 
 message Edge {
@@ -180,27 +158,8 @@ message Edge {
 /**
  * Specifies the result of a TakeAction RPC call.
  * Used as a subfield of the GameEvent response.
- * Dependingon the GameAction, there is a different payload, as specified in the mapping below
- * GAME_ACTION_NONE --> No Action Result
- * INITIAL_PLACEMENT --> No Action Result
- * ROLL_DICE --> roll, resources_transacted
- * MOVE_ROBBER_AND_STEAL --> card
- * BUILD_ROAD --> resources_transacted
- * BUILD_SETTLEMENT --> resources_transacted
- * BUILD_CITY --> resources_transacted
- * BUILD_DEVELOPMENT_CARD --> resources_transacted
- * ACTIVATE_KNIGHT --> card
- * ACTIVATE_ROAD_BUILDING --> No Action Result
- * ACTIVATE_YEAR_OF_PLENTY --> resources_transacted
- * ACTIVATE_MONOPOLY --> resources_transacted
- * PROPOSE_TRADE --> No Action Result
- * PORT_TRADE --> resources_transacted
- * ACCEPT_TRADE --> resources_transacted
- * REJECT_TRADE --> No Action Result
- * DISCARD --> resources_transacted
- * END_TURN --> No Action Result
- * ACKNOWLEDGE --> N/A
- * For more information, see GameEvent
+ * Depending on the GameAction, there is a different payload, as specified in the mapping below.
+ * For more inforamtion see GameEvent.
  **/
 message ActionResult {
   int32 roll = 1;

--- a/src/main/protobuf/game.proto
+++ b/src/main/protobuf/game.proto
@@ -9,6 +9,17 @@ service CatanServer {
   rpc TakeAction(TakeActionRequest) returns (MoveResponse) {}
 }
 
+/**
+ * A GameMessage is the datum streamed from the Catan game server to all subscribers (genearlly players)
+ * The GameMessage comes in one of two flavors. Either it is an ActionRequest or a GameEvent.
+ * An ActionRequest specifies the player which should perform an action and what type of action.
+ * The GameEvent reflects the result of an action taken by a player, or otherwise an update from the server to players.
+ * For example, proposing a trade is a GameEvent, even though no game state has changed.
+ * Similarly, notifying players the game has started or ended is a GameEvent (even though no game state has changed).
+ * Further examples of "stateless" changes are turns ending or a roll on which no player picks up resources.
+ * More typical of a GameEvent, is a corresponding state change. In these cases, the result field of the GameEvent will be populated.
+ * In nearly all cases, the GameEvent is directly triggered by a TakeActionRequest.
+ */
 message GameMessage {
   oneof payload {
     ActionRequest request = 1;
@@ -16,10 +27,13 @@ message GameMessage {
   }
 }
 
+/**
+ * GameMessage targeted at a specific player, telling that player a specific action is requested.
+ **/
 message ActionRequest {
   int32 position = 1;
   enum ActionRequestType {
-    ACTION_REQUEST_TYPE_NONE = 0;
+    ACTION_REQUEST_TYPE_NONE = 0; // Best Practice: start enums with a default 0
     ACKNOWLEDGE_PING = 1;
     ACKNOWLEDGE_START_GAME = 2;
     PLACE_INITIAL_SETTLEMENT = 3;
@@ -31,10 +45,19 @@ message ActionRequest {
     ACKNOWLEDGE_TRADE = 9;
   }
   ActionRequestType type = 2;
+  // TODO: This object should probably also contian the game state
 }
 
+/**
+ * The GameAction enum specifies all possible actions a player might take.
+ * It is used both in the TakeAction RPC, but also in the GameEvent response.
+ * In fact, the general pattern for a GameEvent is to pipe through the TakeAction specification into a GameEvent response.
+ * For example:
+ * TakeAction(TakeActionRequest{game_id: 1, position: 3, action: ROLL_DICE}) --> GameEvent{position: 3, action: ROLL_DICE, result: {roll: 8}}
+ * Notice the same action is used to specify the request and is then echoed back in the response.
+ **/
 enum GameAction {
-  GAME_ACTION_NONE = 0;
+  GAME_ACTION_NONE = 0; // Best Practice: start enum with default 0
   INITIAL_PLACEMENT = 1;
   ROLL_DICE = 2;
   MOVE_ROBBER_AND_STEAL = 3;
@@ -53,24 +76,102 @@ enum GameAction {
   REJECT_TRADE = 16;
   DISCARD = 17;
   END_TURN = 18;
-  ACKNOWLEDGE = 19;
+  // Should we have a seperate way of acknowleding game start vs akcnowledging a trade vs acknowleding a ping?
+  // Should we add another rpc call for acknowledge other than TakeAction?
+  ACKNOWLEDGE = 19; 
 }
 
+/**
+ * Encapsulates a GameEvent response from the Catan game server.
+ * All fields are optional (leaving the action blank will default it to the enum value 0 GAME_ACTION_NONE).
+ * Depending on the type of action, different combinations of fields will be specified.
+ * Examples:
+ * GameEvent {
+ *   position:-1, 
+ *   action: GAME_ACTION_NONE,
+ *   specification: null,
+ *   result: null,
+ *   message: "GAME END"
+ *  }
+ * GameEvent {
+ *   position: 2
+ *   action: MOVE_ROBBER_AND_STEAL,
+ *   specification: {hex: B4, other_player_position: 1},
+ *   result: {card: HiddenCard{ viewable_by_positions: [1, 2], encrypted_name: "askdgi4858fjmcd39932"}},
+ *   message: null
+ * }
+ * GameEvent {
+ *   position: 2
+ *   action: ACTIVATE_MONOPOLY,
+ *   specification: {ask: ORE},
+ *   result: {resources_transacted: {
+ *     1: {gain: [], lose: [ORE, ORE, ORE, ORE]},
+ *     2: {gain: [ORE, ORE, ORE, ORE, ORE, ORE], lose: []},
+ *     3: {gain: [], lose: [ORE, ORE]},
+ *     4: {gain: [] lose: []},
+ *   message: null
+ * }
+ * GameEvent {
+ *   position: 3, 
+ *   action: BUILD_CITY,
+ *   specification: {vertex: B4R},
+ *   result: {resources_transacted: {
+ *     1: {gain: [], lose: []},
+ *     2: {gain: [], lose: []},
+ *     3: { gain: [], lose: [ORE, ORE, ORE, WHEAT, WHEAT]},
+ *     4: {gain: [] lose: []},
+ *   message: null
+ *  }
+ * Important to note, is that multiple actions are able to recycle specification.
+ * For example, BUILD_CITY and BUILD_ROAD have the same specification.
+ * Similarly proposing a trade, making a trade, playing a monopoly or a year of plenty
+ * all take advantage of one or both of the `ask` and `give` fields in the ActionSpecification.
+ **/
 message GameEvent {
-  int32 position = 1;
+  int32 position = 1; // Player positions on the server need to be 1 not 0 based, so 0 can indicate no position, or we can pass -1
   GameAction action = 2;
   ActionSpecification specification = 3;
   ActionResult result = 4;
   string message = 5;
 }
 
+/**
+ * Defines the action a player wants to make.
+ * Is used both in the TakeAction RPC and in the GameEvent response.
+ * Of note, like the GameAction enum, the ActionSpecification object used in the TaekAction RPC
+ * is directly piped through into the GameEvent response.
+ * The GameEvent response might optionally also inlcude a result.
+ * For more inforamtion see GameEvent.
+ * Depending on the action being taken, different combinations of the below fields will be specified.
+ * See mapping below:
+ * GAME_ACTION_NONE --> No Action Spec
+ * INITIAL_PLACEMENT --> vertex, edge
+ * ROLL_DICE --> No Action Spec
+ * MOVE_ROBBER_AND_STEAL --> hex, other_player
+ * BUILD_ROAD --> edge
+ * BUILD_SETTLEMENT --> vertex
+ * BUILD_CITY --> vertex
+ * BUILD_DEVELOPMENT_CARD --> No Action Spec
+ * ACTIVATE_KNIGHT --> hex, other_player
+ * ACTIVATE_ROAD_BUILDING --> edges
+ * ACTIVATE_YEAR_OF_PLENTY --> ask
+ * ACTIVATE_MONOPOLY --> ask
+ * ACTIVATE_VICTORY_POINT --> No Action Spec
+ * PROPOSE_TRADE --> ask, give
+ * PORT_TRADE --> ask, give
+ * ACCEPT_TRADE --> ask, give
+ * REJECT_TRADE --> ask, give
+ * DISCARD --> give
+ * END_TURN --> No Action Spec
+ * ACKNOWLEDGE --> No Action Spec
+ **/
 message ActionSpecification {
   string hex = 2;
   string vertex = 3;
   Edge edge = 4;
   repeated Edge edges = 5; // Road Building
   int32 other_player_position = 7; // Trade, Steal
-  repeated Resource ask = 8; // Trade, Monopoly
+  repeated Resource ask = 8; // Trade, Monopoly, Year of Plenty
   repeated Resource give = 9; // Trade, Discard
 }
 
@@ -79,10 +180,21 @@ message Edge {
   string v2 = 2;
 }
 
+/**
+ * Specifies the result of a TakeAction RPC call.
+ * Used as a subfield of the GameEvent response.
+ * Dependingon the GameAction, there is a different payload, as specified in the mapping below
+ * GAME_ACTION_NONE, INITIAL_PLACEMENT, ACTIVATE_VICTORY_POINT, PROPOSE_TRADE, REJECT_TRADE, END_TURN, ACKNOWLEDGE   --> No Action Result
+ * ROLL_DICE --> roll, resources_transacted
+ * MOVE_ROBBER_AND_STEAL,   ACTIVATE_KNIGHT --> HiddenCard
+ * BUILD_ROAD, BUILD_SETTLEMENT, BUILD_CITY, BUILD_DEVELOPMENT_CARD,  ACTIVATE_ROAD_BUILDING, ACTIVATE_YEAR_OF_PLENTY, ACTIVATE_MONOPOLY, PORT_TRADE, ACCEPT_TRADE,  DISCARD --> resources_transacted
+ * For more information, see GameEvent
+ **/
 message ActionResult {
+  // TODO: I think this should be a 'oneof' is there any action that might include multiple of these fields as its result?
   int32 roll = 1;
   HiddenCard card = 2;
-  map<int32, ResourceTransaction> resources_transacted = 3;
+  map<int32, ResourceTransaction> resources_transacted = 3; // Only shows publically transacted resources
 }
 
 message ResourceTransaction {
@@ -90,13 +202,20 @@ message ResourceTransaction {
   repeated Resource lose = 2;
 }
 
+/**
+ * Specifies a card that exchanged hands via a steal or a newly drawn development card.
+ * In both cases, there are only certain players that can see this card.
+ * Those player positions are specified, and the name of the card is encrypted using those clients' keys.
+ * Note: Usually resources and development cards are specified as an enum, in this case they are not.
+ * The client will have to map the string to the enum value. 
+ **/
 message HiddenCard {
   repeated int32 viewable_by_positions = 1;
   string encrypted_name = 2; // One of: "BRICK", "ORE", "SHEEP", "WHEAT", "WOOD", "KNIGHT", "VICTORY_POINT", "MONOPOLY", "YEAR_OF_PLENTY", "ROAD_BUILDING"
 }
 
 enum Resource {
-  RESOURCE_NONE = 0;
+  RESOURCE_NONE = 0; // Best Practice: start enum with default 0
   BRICK = 1;
   ORE = 2;
   SHEEP = 3;
@@ -104,6 +223,11 @@ enum Resource {
   WOOD = 5;
 }
 
+/**
+ * Specifies the action a player woiuld like to take.
+ * Must include an action field, and certain action require a specification.
+ * For more details see GameAction and ActionSpecification.
+ **/
 message TakeActionRequest {
   string game_id = 1;
   int32 position = 2;

--- a/src/main/protobuf/game.proto
+++ b/src/main/protobuf/game.proto
@@ -39,7 +39,7 @@ enum GameAction {
   BUILD_ROAD = 3;
   BUILD_SETTLEMENT = 4;
   BUILD_CITY = 5;
-  BUILD_DEVELOPMENT = 6;
+  BUILD_DEVELOPMENT_CARD = 6;
   ACTIVATE_KNIGHT = 7;
   ACTIVATE_ROAD_BUILDING = 8;
   ACTIVATE_YEAR_OF_PLENTY= 9;
@@ -64,11 +64,16 @@ message GameEvent {
 message ActionSpecification {
   string hex = 2;
   string vertex = 3;
-  string edge = 4;
-  repeated string edges = 5; // Road Building
+  Edge edge = 4;
+  repeated Edge edges = 5; // Road Building
   int32 other_player_position = 7; // Trade, Steal
   repeated Resource ask = 8; // Trade, Monopoly
   repeated Resource give = 9; // Trade, Discard
+}
+
+message Edge {
+  string v1 = 1;
+  string v2 = 2;
 }
 
 message ActionResult {
@@ -78,13 +83,13 @@ message ActionResult {
 }
 
 message ResourceTransaction {
-  repeated Resource lose = 1;
-  repeated Resource gain = 2;
+  repeated Resource gain = 1;
+  repeated Resource lose = 2;
 }
 
 message HiddenCard {
   repeated int32 viewable_by_positions = 1;
-  string value = 2;
+  string encrypted_name = 2; // One of: "CLAY", "SHEEP", "STONE", "WHEAT", "WOOD", "KNIGHT", "VICTORY_POINT", "MONOPOLY", "YEAR_OF_PLENTY", "ROAD_BUILDING"
 }
 
 enum Resource {
@@ -109,14 +114,6 @@ message SubscribeRequest {
   int32 position = 4; // Optional, raises an exception if type = OBSERVER. If not supplied default to next open position.
 }
 
-// NOTE: for now there is no authentication,
-// we can handle it a layer up, or we can register players with tokens they have to pass
-message MoveRequest {
-  string game_id = 1;
-  int32 position = 2; 
-  // We can create an action schema
-  string action = 3;
-}
 
 message MoveResponse {
   // We can make this response richer

--- a/src/main/protobuf/game.proto
+++ b/src/main/protobuf/game.proto
@@ -19,38 +19,41 @@ message GameMessage {
 message ActionRequest {
   int32 position = 1;
   enum ActionRequestType {
-    ACKNOWLEDGE_PING = 0;
-    ACKNOWLEDGE_START_GAME = 1;
-    PLACE_INITIAL_SETTLEMENT = 2;
-    START_TURN = 3;
-    BUILD_OR_TRADE_OR_PLAY_OR_PASS = 4;
-    MOVE_ROBBER = 5;
-    DISCARD = 6;
-    ACCEPT_OR_REJECT_TRADE = 7;
-    ACKNOWLEDGE_TRADE = 8;
+    ACTION_REQUEST_TYPE_NONE = 0;
+    ACKNOWLEDGE_PING = 1;
+    ACKNOWLEDGE_START_GAME = 2;
+    PLACE_INITIAL_SETTLEMENT = 3;
+    START_TURN = 4;
+    BUILD_OR_TRADE_OR_PLAY_OR_PASS = 5;
+    MOVE_ROBBER = 6;
+    DISCARD = 7;
+    ACCEPT_OR_REJECT_TRADE = 8;
+    ACKNOWLEDGE_TRADE = 9;
   }
   ActionRequestType type = 2;
 }
 
 enum GameAction {
-  INITIAL_PLACEMENT = 0;
-  ROLL_DICE = 1;
-  MOVE_ROBBER_AND_STEAL = 2;
-  BUILD_ROAD = 3;
-  BUILD_SETTLEMENT = 4;
-  BUILD_CITY = 5;
-  BUILD_DEVELOPMENT_CARD = 6;
-  ACTIVATE_KNIGHT = 7;
-  ACTIVATE_ROAD_BUILDING = 8;
-  ACTIVATE_YEAR_OF_PLENTY= 9;
-  ACTIVATE_MONOPOLY = 10;
-  ACTIVATE_VICTORY_POINT = 11;
-  PROPOSE_TRADE = 12;
-  PORT_TRADE = 13;
-  ACCEPT_TRADE = 14;
-  REJECT_TRADE = 15;
-  DISCARD = 16;
-  END_TURN = 17;
+  GAME_ACTION_NONE = 0;
+  INITIAL_PLACEMENT = 1;
+  ROLL_DICE = 2;
+  MOVE_ROBBER_AND_STEAL = 3;
+  BUILD_ROAD = 4;
+  BUILD_SETTLEMENT = 5;
+  BUILD_CITY = 6;
+  BUILD_DEVELOPMENT_CARD = 7;
+  ACTIVATE_KNIGHT = 8;
+  ACTIVATE_ROAD_BUILDING = 9;
+  ACTIVATE_YEAR_OF_PLENTY= 10;
+  ACTIVATE_MONOPOLY = 11;
+  ACTIVATE_VICTORY_POINT = 12;
+  PROPOSE_TRADE = 13;
+  PORT_TRADE = 14;
+  ACCEPT_TRADE = 15;
+  REJECT_TRADE = 16;
+  DISCARD = 17;
+  END_TURN = 18;
+  ACKNOWLEDGE = 19;
 }
 
 message GameEvent {
@@ -89,15 +92,16 @@ message ResourceTransaction {
 
 message HiddenCard {
   repeated int32 viewable_by_positions = 1;
-  string encrypted_name = 2; // One of: "CLAY", "SHEEP", "STONE", "WHEAT", "WOOD", "KNIGHT", "VICTORY_POINT", "MONOPOLY", "YEAR_OF_PLENTY", "ROAD_BUILDING"
+  string encrypted_name = 2; // One of: "BRICK", "ORE", "SHEEP", "WHEAT", "WOOD", "KNIGHT", "VICTORY_POINT", "MONOPOLY", "YEAR_OF_PLENTY", "ROAD_BUILDING"
 }
 
 enum Resource {
-  CLAY = 0;
-  SHEEP = 1;
-  STONE = 2;
-  WHEAT = 3;
-  WOOD = 4;
+  RESOURCE_NONE = 0;
+  BRICK = 1;
+  ORE = 2;
+  SHEEP = 3;
+  WHEAT = 4;
+  WOOD = 5;
 }
 
 message TakeActionRequest {

--- a/src/main/protobuf/game.proto
+++ b/src/main/protobuf/game.proto
@@ -33,16 +33,15 @@ message GameMessage {
 message ActionRequest {
   int32 position = 1;
   enum ActionRequestType {
-    ACTION_REQUEST_TYPE_NONE = 0; // Best Practice: start enums with a default 0
-    ACKNOWLEDGE_PING = 1;
-    ACKNOWLEDGE_START_GAME = 2;
-    PLACE_INITIAL_SETTLEMENT = 3;
-    START_TURN = 4;
-    BUILD_OR_TRADE_OR_PLAY_OR_PASS = 5;
-    MOVE_ROBBER = 6;
-    DISCARD = 7;
-    ACCEPT_OR_REJECT_TRADE = 8;
-    ACKNOWLEDGE_TRADE = 9;
+    ACKNOWLEDGE_PING = 0;
+    ACKNOWLEDGE_START_GAME = 1;
+    PLACE_INITIAL_SETTLEMENT = 2;
+    START_TURN = 3;
+    BUILD_OR_TRADE_OR_PLAY_OR_PASS = 4;
+    MOVE_ROBBER = 5;
+    DISCARD = 6;
+    ACCEPT_OR_REJECT_TRADE = 7;
+    ACKNOWLEDGE_TRADE = 8;
   }
   ActionRequestType type = 2;
   // TODO: This object should probably also contian the game state
@@ -57,7 +56,7 @@ message ActionRequest {
  * Notice the same action is used to specify the request and is then echoed back in the response.
  **/
 enum GameAction {
-  GAME_ACTION_NONE = 0; // Best Practice: start enum with default 0
+  GAME_ACTION_NONE = 0;
   INITIAL_PLACEMENT = 1;
   ROLL_DICE = 2;
   MOVE_ROBBER_AND_STEAL = 3;
@@ -69,16 +68,15 @@ enum GameAction {
   ACTIVATE_ROAD_BUILDING = 9;
   ACTIVATE_YEAR_OF_PLENTY= 10;
   ACTIVATE_MONOPOLY = 11;
-  ACTIVATE_VICTORY_POINT = 12;
-  PROPOSE_TRADE = 13;
-  PORT_TRADE = 14;
-  ACCEPT_TRADE = 15;
-  REJECT_TRADE = 16;
-  DISCARD = 17;
-  END_TURN = 18;
+  PROPOSE_TRADE = 12;
+  PORT_TRADE = 13;
+  ACCEPT_TRADE = 14;
+  REJECT_TRADE = 15;
+  DISCARD = 16;
+  END_TURN = 17;
   // Should we have a seperate way of acknowleding game start vs akcnowledging a trade vs acknowleding a ping?
   // Should we add another rpc call for acknowledge other than TakeAction?
-  ACKNOWLEDGE = 19; 
+  ACKNOWLEDGE = 18; 
 }
 
 /**
@@ -147,16 +145,15 @@ message GameEvent {
  * GAME_ACTION_NONE --> No Action Spec
  * INITIAL_PLACEMENT --> vertex, edge
  * ROLL_DICE --> No Action Spec
- * MOVE_ROBBER_AND_STEAL --> hex, other_player
+ * MOVE_ROBBER_AND_STEAL --> hex, other_player (optional)
  * BUILD_ROAD --> edge
  * BUILD_SETTLEMENT --> vertex
  * BUILD_CITY --> vertex
  * BUILD_DEVELOPMENT_CARD --> No Action Spec
  * ACTIVATE_KNIGHT --> hex, other_player
- * ACTIVATE_ROAD_BUILDING --> edges
+ * ACTIVATE_ROAD_BUILDING --> edges OR edge
  * ACTIVATE_YEAR_OF_PLENTY --> ask
  * ACTIVATE_MONOPOLY --> ask
- * ACTIVATE_VICTORY_POINT --> No Action Spec
  * PROPOSE_TRADE --> ask, give
  * PORT_TRADE --> ask, give
  * ACCEPT_TRADE --> ask, give
@@ -184,14 +181,28 @@ message Edge {
  * Specifies the result of a TakeAction RPC call.
  * Used as a subfield of the GameEvent response.
  * Dependingon the GameAction, there is a different payload, as specified in the mapping below
- * GAME_ACTION_NONE, INITIAL_PLACEMENT, ACTIVATE_VICTORY_POINT, PROPOSE_TRADE, REJECT_TRADE, END_TURN, ACKNOWLEDGE   --> No Action Result
+ * GAME_ACTION_NONE --> No Action Result
+ * INITIAL_PLACEMENT --> No Action Result
  * ROLL_DICE --> roll, resources_transacted
- * MOVE_ROBBER_AND_STEAL,   ACTIVATE_KNIGHT --> HiddenCard
- * BUILD_ROAD, BUILD_SETTLEMENT, BUILD_CITY, BUILD_DEVELOPMENT_CARD,  ACTIVATE_ROAD_BUILDING, ACTIVATE_YEAR_OF_PLENTY, ACTIVATE_MONOPOLY, PORT_TRADE, ACCEPT_TRADE,  DISCARD --> resources_transacted
+ * MOVE_ROBBER_AND_STEAL --> card
+ * BUILD_ROAD --> resources_transacted
+ * BUILD_SETTLEMENT --> resources_transacted
+ * BUILD_CITY --> resources_transacted
+ * BUILD_DEVELOPMENT_CARD --> resources_transacted
+ * ACTIVATE_KNIGHT --> card
+ * ACTIVATE_ROAD_BUILDING --> No Action Result
+ * ACTIVATE_YEAR_OF_PLENTY --> resources_transacted
+ * ACTIVATE_MONOPOLY --> resources_transacted
+ * PROPOSE_TRADE --> No Action Result
+ * PORT_TRADE --> resources_transacted
+ * ACCEPT_TRADE --> resources_transacted
+ * REJECT_TRADE --> No Action Result
+ * DISCARD --> resources_transacted
+ * END_TURN --> No Action Result
+ * ACKNOWLEDGE --> N/A
  * For more information, see GameEvent
  **/
 message ActionResult {
-  // TODO: I think this should be a 'oneof' is there any action that might include multiple of these fields as its result?
   int32 roll = 1;
   HiddenCard card = 2;
   map<int32, ResourceTransaction> resources_transacted = 3; // Only shows publically transacted resources
@@ -205,22 +216,34 @@ message ResourceTransaction {
 /**
  * Specifies a card that exchanged hands via a steal or a newly drawn development card.
  * In both cases, there are only certain players that can see this card.
- * Those player positions are specified, and the name of the card is encrypted using those clients' keys.
- * Note: Usually resources and development cards are specified as an enum, in this case they are not.
- * The client will have to map the string to the enum value. 
+ * The players who can see the card are specified via the viewable_by_positions field.
+ * Players in this array will see the corresponding resource or development card
+ * All other players will receive `null` in the payload field
  **/
 message HiddenCard {
   repeated int32 viewable_by_positions = 1;
-  string encrypted_name = 2; // One of: "BRICK", "ORE", "SHEEP", "WHEAT", "WOOD", "KNIGHT", "VICTORY_POINT", "MONOPOLY", "YEAR_OF_PLENTY", "ROAD_BUILDING"
+  oneof payload {
+    Resource resource = 2;
+    DevelopmentCard development_card = 3;
+  }
 }
 
 enum Resource {
-  RESOURCE_NONE = 0; // Best Practice: start enum with default 0
+  RESOURCE_NONE = 0;
   BRICK = 1;
   ORE = 2;
   SHEEP = 3;
   WHEAT = 4;
   WOOD = 5;
+}
+
+enum DevelopmentCard {
+  DEVELOPMENT_CARD_NONE = 0;
+  KNIGHT = 1;
+  VICTORY_POINT = 2;
+  YEAR_OF_PLENTY = 3;
+  ROAD_BUILDING = 4;
+  MONOPOLY = 5;
 }
 
 /**

--- a/src/main/protobuf/game.proto
+++ b/src/main/protobuf/game.proto
@@ -7,14 +7,185 @@ service CatanServer {
   rpc CreateGame (CreateGameRequest) returns (CreateGameResponse) {}
   rpc StartGame (StartGameRequest) returns (StartGameResponse) {}
   // Subscribe to a game to recieve all its notifications
-  rpc Subscribe(SubscribeRequest) returns (stream GameUpdate) {}
-  rpc Move(MoveRequest) returns (MoveResponse) {}
+  rpc Subscribe(SubscribeRequest) returns (stream GameMessage) {}
+  rpc Move(Action) returns (MoveResponse) {}
 }
 
+message GameMessage {
+  oneof payload {
+    ActionRequest request = 1;
+    GameUpdate update = 2;
+    GameEvent event = 3;
+  }
+}
+
+message ActionRequest {
+  int32 position = 1;
+  enum ActionRequestType {
+    ACKNOWLEDGE_PING = 0;
+    ACKNOWLEDGE_START_GAME = 1;
+    PLACE_INITIAL_SETTLEMENT = 2;
+    START_TURN = 3;
+    BUILD_OR_TRADE_OR_PLAY_OR_PASS = 4;
+    MOVE_ROBBER = 5;
+    DISCARD = 6;
+    ACCEPT_OR_REJECT_TRADE = 7;
+    ACKNOWLEDGE_TRADE = 8;
+  }
+  ActionRequestType type = 2;
+}
+
+enum GameAction {
+  ROLL_DICE = 0;
+  MOVE_ROBBER_AND_STEAL = 1;
+  BUILD_ROAD = 2;
+  BUILD_SETTLEMENT = 3;
+  BUILD_CITY_BUILD = 4;
+  BUILD_DEVELOPMENT = 5;
+  ACTIVATE_KNIGHT = 6;
+  ACTIVATE_YEAR_OF_PLENTY= 7;
+  ACTIVATE_MONOPOLY = 8;
+  ACTIVATE_VICTORY_POINT = 9;
+  PROPOSE_TRADE = 10
+  PORT_TRADE = 11;
+  ACCEPT_TRADE = 12;
+  REJECT_TRADE = 13;
+  DISCARD = 14;
+}
+
+
+
 message GameUpdate {
-  repeated string action_requested_players = 1;
-  string payload = 2; // TODO: define a rich type
-  int32 position = 3;
+  int32 postition = 1;
+  GameAction action = 2;
+  oneof result {
+    int32 roll = 1;
+    MoverRobberAndStealResult move_robber_and_steal = 2;
+    VertexLocation vertex_location = 3;
+    EdgeLocation edge_location = 4;
+    repeatead EdgeLocation road_locations = 5;
+    HiddenResult card = 6;
+    Trade trade = 7;
+  }
+  oneof result {
+    DiceRoll dice_roll = 1;
+    MoveRobberAndSteal move_robber_and_steal = 3;
+    RoadBuild road_build = 3;
+    SettlementBuild settlement_build = 4;
+    CityBuilt city_build = 5;
+    DevelopmentCardPurchase development_card_purchase = 6;
+    KnightActivation knight_activation = 7;
+    YearOfPlentyActivation year_of_plenty_activation = 8;
+    MonopolyActivation monopoly_activation = 9;
+    VictoryPointActivation victory_point_activation = 10;
+    PortTrade port_trade = 11;
+    PlayerTrade player_trade = 12;
+  }
+}
+
+message ActionResult {
+  int32 roll = 1;
+  string hex = 2;
+  string vertex = 3;
+  string edge = 4;
+  repeated string edges = 5; // RoadBuilding
+  HiddenCard card = 6; // Steal, Build Dev Card
+  int32 other_player = 7; // Trade, Steal
+  repeated Resource ask = 8; // Propose Trade, Monoploy
+  repeated Resource give = 9; // Propose Trade
+  map<int32, ResourceTransaction> public_resource_transactions = 10;
+}
+
+message ResourceTransaction {
+  repeated Resource lose = 1;
+  repeated Resource gain = 2;
+}
+
+message DiceRoll {
+  int32 roll = 1;
+}
+
+message MoveRobberAndSteal {
+  string hex = 1;
+  int32 stolen_from_position = 2;
+  HiddenMessage card = 3;
+}
+
+message RoadBuild {
+  string vertex1 = 1;
+  string vertex2 = 2;
+}
+
+message SettlementBuild {
+  string vertex = 1;
+}
+
+message CityBuild {
+  string vertex1 = 1;
+}
+
+message DevelopmentCardPurchase {
+  HiddenMessage card = 1;
+}
+
+message KnightActivation {
+  string hex = 1;
+  int32 stolen_from_position = 2;
+  HiddenMessage card = 3;
+}
+
+message YearOfPlenetyActivation {
+  Resource resource1 = 1;
+  Resource resource2 = 2;
+}
+
+message MonoployActivation {
+  Resource resource = 1;
+}
+
+message RoadBuildingActivation {
+  string road1_vertex1 = 1;
+  string road1_vertex2 = 2;
+  string road2_vertex1 = 3;
+  string road2_vertex2 = 4;
+}
+
+message VictoryPointActivation {
+  // pass
+}
+
+message PortTrade {
+  repeated Resource send = 1;
+  repeated Resource receive = 2;
+}
+
+message PlayerTrade {
+  int32 trade_with_position = 1;
+  repeated Resource send = 2;
+  repeated Resource receive = 3;
+}
+
+message HiddenCard {
+  repeated int32 viewable_by_positions = 1;
+  string value = 2;
+}
+
+enum Resource {
+  CLAY = 0;
+  SHEEP = 1;
+  STONE = 2;
+  WHEAT = 3;
+  WOOD = 4;
+}
+
+// This would get broadcast when a player proposes a trade
+// Are there other 'events' that would get broadcast that don't impact state change?
+// Should this just be called TradeProposal? 
+// How do we handle counter proposals? 
+// What if in the future the AI can ask other players where they think it should place the Robber?
+// Another type of game event could be pausing the game?
+message GameEvent {
+
 }
 
 message SubscribeRequest {
@@ -22,9 +193,8 @@ message SubscribeRequest {
   string name = 2;
   string type = 3; // ie. PLAYER, OBSERVER TODO: See if there are enums
   int32 position = 4; // Optional, raises an exception if type = OBSERVER. If not supplied default to next open position.
+
 }
-
-
 
 // NOTE: for now there is no authentication,
 // we can handle it a layer up, or we can register players with tokens they have to pass
@@ -45,16 +215,13 @@ message CreateGameRequest {
   // Or an existing saved board state
   // Or even the strategies
   // It could also take settings about the game (like where to output the results)
-  // Should include game parameters such as game rules and number of players
   // maybe string status?
 }
-
 
 message CreateGameResponse {
   string game_id = 1;
 }
 
-//This should raise an exception if number of players needed for game have not subscribed
 message StartGameRequest {
   string game_id = 1;
 }

--- a/src/main/protobuf/game.proto
+++ b/src/main/protobuf/game.proto
@@ -2,20 +2,17 @@ syntax = "proto3";
 
 package soc.protos;
 
-// All RPCs must have a request and response message, even if empty
 service CatanServer {
   rpc CreateGame (CreateGameRequest) returns (CreateGameResponse) {}
   rpc StartGame (StartGameRequest) returns (StartGameResponse) {}
-  // Subscribe to a game to recieve all its notifications
   rpc Subscribe(SubscribeRequest) returns (stream GameMessage) {}
-  rpc Move(Action) returns (MoveResponse) {}
+  rpc TakeAction(TakeActionRequest) returns (MoveResponse) {}
 }
 
 message GameMessage {
   oneof payload {
     ActionRequest request = 1;
-    GameUpdate update = 2;
-    GameEvent event = 3;
+    GameEvent event = 2;
   }
 }
 
@@ -36,133 +33,53 @@ message ActionRequest {
 }
 
 enum GameAction {
-  ROLL_DICE = 0;
-  MOVE_ROBBER_AND_STEAL = 1;
-  BUILD_ROAD = 2;
-  BUILD_SETTLEMENT = 3;
-  BUILD_CITY_BUILD = 4;
-  BUILD_DEVELOPMENT = 5;
-  ACTIVATE_KNIGHT = 6;
-  ACTIVATE_YEAR_OF_PLENTY= 7;
-  ACTIVATE_MONOPOLY = 8;
-  ACTIVATE_VICTORY_POINT = 9;
-  PROPOSE_TRADE = 10
-  PORT_TRADE = 11;
-  ACCEPT_TRADE = 12;
-  REJECT_TRADE = 13;
-  DISCARD = 14;
+  INITIAL_PLACEMENT = 0;
+  ROLL_DICE = 1;
+  MOVE_ROBBER_AND_STEAL = 2;
+  BUILD_ROAD = 3;
+  BUILD_SETTLEMENT = 4;
+  BUILD_CITY = 5;
+  BUILD_DEVELOPMENT = 6;
+  ACTIVATE_KNIGHT = 7;
+  ACTIVATE_ROAD_BUILDING = 8;
+  ACTIVATE_YEAR_OF_PLENTY= 9;
+  ACTIVATE_MONOPOLY = 10;
+  ACTIVATE_VICTORY_POINT = 11;
+  PROPOSE_TRADE = 12;
+  PORT_TRADE = 13;
+  ACCEPT_TRADE = 14;
+  REJECT_TRADE = 15;
+  DISCARD = 16;
+  END_TURN = 17;
 }
 
-
-
-message GameUpdate {
-  int32 postition = 1;
+message GameEvent {
+  int32 position = 1;
   GameAction action = 2;
-  oneof result {
-    int32 roll = 1;
-    MoverRobberAndStealResult move_robber_and_steal = 2;
-    VertexLocation vertex_location = 3;
-    EdgeLocation edge_location = 4;
-    repeatead EdgeLocation road_locations = 5;
-    HiddenResult card = 6;
-    Trade trade = 7;
-  }
-  oneof result {
-    DiceRoll dice_roll = 1;
-    MoveRobberAndSteal move_robber_and_steal = 3;
-    RoadBuild road_build = 3;
-    SettlementBuild settlement_build = 4;
-    CityBuilt city_build = 5;
-    DevelopmentCardPurchase development_card_purchase = 6;
-    KnightActivation knight_activation = 7;
-    YearOfPlentyActivation year_of_plenty_activation = 8;
-    MonopolyActivation monopoly_activation = 9;
-    VictoryPointActivation victory_point_activation = 10;
-    PortTrade port_trade = 11;
-    PlayerTrade player_trade = 12;
-  }
+  ActionSpecification specification = 3;
+  ActionResult result = 4;
+  string message = 5;
+}
+
+message ActionSpecification {
+  string hex = 2;
+  string vertex = 3;
+  string edge = 4;
+  repeated string edges = 5; // Road Building
+  int32 other_player_position = 7; // Trade, Steal
+  repeated Resource ask = 8; // Trade, Monopoly
+  repeated Resource give = 9; // Trade, Discard
 }
 
 message ActionResult {
   int32 roll = 1;
-  string hex = 2;
-  string vertex = 3;
-  string edge = 4;
-  repeated string edges = 5; // RoadBuilding
-  HiddenCard card = 6; // Steal, Build Dev Card
-  int32 other_player = 7; // Trade, Steal
-  repeated Resource ask = 8; // Propose Trade, Monoploy
-  repeated Resource give = 9; // Propose Trade
-  map<int32, ResourceTransaction> public_resource_transactions = 10;
+  HiddenCard card = 2;
+  map<int32, ResourceTransaction> resources_transacted = 3;
 }
 
 message ResourceTransaction {
   repeated Resource lose = 1;
   repeated Resource gain = 2;
-}
-
-message DiceRoll {
-  int32 roll = 1;
-}
-
-message MoveRobberAndSteal {
-  string hex = 1;
-  int32 stolen_from_position = 2;
-  HiddenMessage card = 3;
-}
-
-message RoadBuild {
-  string vertex1 = 1;
-  string vertex2 = 2;
-}
-
-message SettlementBuild {
-  string vertex = 1;
-}
-
-message CityBuild {
-  string vertex1 = 1;
-}
-
-message DevelopmentCardPurchase {
-  HiddenMessage card = 1;
-}
-
-message KnightActivation {
-  string hex = 1;
-  int32 stolen_from_position = 2;
-  HiddenMessage card = 3;
-}
-
-message YearOfPlenetyActivation {
-  Resource resource1 = 1;
-  Resource resource2 = 2;
-}
-
-message MonoployActivation {
-  Resource resource = 1;
-}
-
-message RoadBuildingActivation {
-  string road1_vertex1 = 1;
-  string road1_vertex2 = 2;
-  string road2_vertex1 = 3;
-  string road2_vertex2 = 4;
-}
-
-message VictoryPointActivation {
-  // pass
-}
-
-message PortTrade {
-  repeated Resource send = 1;
-  repeated Resource receive = 2;
-}
-
-message PlayerTrade {
-  int32 trade_with_position = 1;
-  repeated Resource send = 2;
-  repeated Resource receive = 3;
 }
 
 message HiddenCard {
@@ -178,14 +95,11 @@ enum Resource {
   WOOD = 4;
 }
 
-// This would get broadcast when a player proposes a trade
-// Are there other 'events' that would get broadcast that don't impact state change?
-// Should this just be called TradeProposal? 
-// How do we handle counter proposals? 
-// What if in the future the AI can ask other players where they think it should place the Robber?
-// Another type of game event could be pausing the game?
-message GameEvent {
-
+message TakeActionRequest {
+  string game_id = 1;
+  int32 position = 2;
+  GameAction action = 3;
+  ActionSpecification action_specification = 4;
 }
 
 message SubscribeRequest {
@@ -193,7 +107,6 @@ message SubscribeRequest {
   string name = 2;
   string type = 3; // ie. PLAYER, OBSERVER TODO: See if there are enums
   int32 position = 4; // Optional, raises an exception if type = OBSERVER. If not supplied default to next open position.
-
 }
 
 // NOTE: for now there is no authentication,

--- a/src/main/scala/server/CatanServer.scala
+++ b/src/main/scala/server/CatanServer.scala
@@ -10,7 +10,7 @@ import soc.game.{GameRules, RollDiceMove, CatanMove}
 import soc.game.board.{BaseBoardConfiguration, BaseCatanBoard}
 import soc.game.inventory.Inventory.{NoInfo, PerfectInfo}
 import soc.playerRepository.{PlayerContext, PlayerRepository}
-import soc.protos.game.{CatanServerGrpc, CreateGameRequest, CreateGameResponse, GameMessage, TakeActionRequest, MoveResponse, StartGameRequest, StartGameResponse, SubscribeRequest}
+import soc.protos.game.{GameAction, CatanServerGrpc, CreateGameRequest, CreateGameResponse, GameMessage, TakeActionRequest, MoveResponse, StartGameRequest, StartGameResponse, SubscribeRequest}
 import soc.storage.{GameId, SimulatedGame}
 
 import scala.collection.mutable.HashMap
@@ -118,17 +118,16 @@ private class CatanServerImpl extends CatanServerGrpc.CatanServer {
     println("Take Action: " + req.action + " player: " + req.position)
     val playerContext = games.get(req.gameId).flatMap(_.getPlayer(req.position)).getOrElse(throw new Exception(""))
     // TODO: Actually parse the Action Request
-    val move = playerContext.getLastRequestRandomMove(req.gameId, req.position)
+    val move = if (req.action == GameAction.GAME_ACTION_NONE) playerContext.getLastRequestRandomMove(req.gameId, req.position) else translate(req)
     val result = playerContext.receiveMove(req.gameId, req.position, move)
     Future.successful(new MoveResponse(if (result) "SUCCESS" else "ERROR"))
   }
 
-  // TODO: Move this method somewhere generic
-  // Instead of taking a string, this should take an object defined in the gRPC schema
+
   /**
-   * Takes a move object from the gRPC layer and translates it into a CatanMove object
+   * Takes a TakeActionRequest from the gRPC layer and translates it into a CatanMove object
    **/
-  def translate(action: String): CatanMove = {
+  def translate(action: TakeActionRequest): CatanMove = {
       // TODO: Implement
       return null
 

--- a/src/main/scala/server/CatanServer.scala
+++ b/src/main/scala/server/CatanServer.scala
@@ -10,7 +10,7 @@ import soc.game.{GameRules, RollDiceMove, CatanMove}
 import soc.game.board.{BaseBoardConfiguration, BaseCatanBoard}
 import soc.game.inventory.Inventory.{NoInfo, PerfectInfo}
 import soc.playerRepository.{PlayerContext, PlayerRepository}
-import soc.protos.game.{CatanServerGrpc, CreateGameRequest, CreateGameResponse, GameUpdate, MoveRequest, MoveResponse, StartGameRequest, StartGameResponse, SubscribeRequest}
+import soc.protos.game.{CatanServerGrpc, CreateGameRequest, CreateGameResponse, GameMessage, TakeActionRequest, MoveResponse, StartGameRequest, StartGameResponse, SubscribeRequest}
 import soc.storage.{GameId, SimulatedGame}
 
 import scala.collection.mutable.HashMap
@@ -101,7 +101,7 @@ private class CatanServerImpl extends CatanServerGrpc.CatanServer {
     Future.successful(reply)
   }
 
-  override def subscribe(req: SubscribeRequest, responseObserver: StreamObserver[GameUpdate]) = this.synchronized {
+  override def subscribe(req: SubscribeRequest, responseObserver: StreamObserver[GameMessage]) = this.synchronized {
     builders.get(req.gameId) match {
       case Some(gameContext) => {
         println("Registering listener " + req.name)
@@ -114,10 +114,10 @@ private class CatanServerImpl extends CatanServerGrpc.CatanServer {
     }
   }
 
-  override def move(req: MoveRequest) = this.synchronized  {
+  override def takeAction(req: TakeActionRequest) = this.synchronized  {
     val playerContext = games.get(req.gameId).flatMap(_.getPlayer(req.position)).getOrElse(throw new Exception(""))
-    val move = if(req.action == "") playerContext.getLastRequestRandomMove(req.gameId, req.position) else translate(req.action)
-    val result = playerContext.receiveMove(req.gameId, req.position, move)
+    //val move = if(req.action == "") playerContext.getLastRequestRandomMove(req.gameId, req.position) else translate(req.action)
+    val result = playerContext.receiveMove(req.gameId, req.position, null)
     Future.successful(new MoveResponse(if (result) "SUCCESS" else "ERROR"))
   }
 

--- a/src/main/scala/server/CatanServer.scala
+++ b/src/main/scala/server/CatanServer.scala
@@ -115,9 +115,11 @@ private class CatanServerImpl extends CatanServerGrpc.CatanServer {
   }
 
   override def takeAction(req: TakeActionRequest) = this.synchronized  {
+    println("Take Action: " + req.action + " player: " + req.position)
     val playerContext = games.get(req.gameId).flatMap(_.getPlayer(req.position)).getOrElse(throw new Exception(""))
-    //val move = if(req.action == "") playerContext.getLastRequestRandomMove(req.gameId, req.position) else translate(req.action)
-    val result = playerContext.receiveMove(req.gameId, req.position, null)
+    // TODO: Actually parse the Action Request
+    val move = playerContext.getLastRequestRandomMove(req.gameId, req.position)
+    val result = playerContext.receiveMove(req.gameId, req.position, move)
     Future.successful(new MoveResponse(if (result) "SUCCESS" else "ERROR"))
   }
 

--- a/src/main/scala/soc/akka/GameBehavior.scala
+++ b/src/main/scala/soc/akka/GameBehavior.scala
@@ -20,7 +20,6 @@ import scala.util.{Failure, Success}
 import scala.concurrent.ExecutionContextExecutor
 import scala.collection.mutable.HashMap
 import io.grpc.stub.StreamObserver
-import soc.protos.game.GameUpdate
 import soc.akka.messages.GameMessage
 
 case class GameStateHolder[GAME <: Inventory[GAME], PLAYERS <: Inventory[PLAYERS]](

--- a/src/main/scala/soc/playerRepository/PlayerContext.scala
+++ b/src/main/scala/soc/playerRepository/PlayerContext.scala
@@ -102,16 +102,16 @@ class PlayerContext[GAME <: Inventory[GAME], PLAYER <: Inventory[PLAYER]](val na
   def getEvent(position: Int, moveResult: MoveResult): GameEvent = {
     moveResult match {
       case InitialPlacementMove(first, settlement, road) => 
-        val actionSpec = ActionSpecification(vertex = settlement.node.toString(), edge = Some(Edge(road.v1.node.toString(), road.v2.node.toString())))
+        val actionSpec = ActionSpecification(vertex = settlement.node.toString(), edges = Seq(Edge(road.v1.node.toString(), road.v2.node.toString())))
         GameEvent(position, GameAction.INITIAL_PLACEMENT, Some(actionSpec))
       case RollResult(roll) => 
         GameEvent(position, GameAction.ROLL_DICE, result = Some(ActionResult(roll=roll.number)))
       case MoveRobberAndStealResult(robberLocation, steal) => 
         val s = steal.getOrElse(null)
         val op = if (s == null) -1 else s.victim
-        GameEvent(position, GameAction.MOVE_ROBBER_AND_STEAL, Some(ActionSpecification(hex = robberLocation.toString(), otherPlayerPosition = op)))
+        GameEvent(position, GameAction.MOVE_ROBBER_AND_STEAL, Some(ActionSpecification(hex = robberLocation.toString(), otherPlayerPositions = Seq(op))))
       case BuildRoadMove(edge) => 
-          val actionSpec = ActionSpecification(edge=Some(Edge(edge.v1.node.toString(), edge.v2.node.toString())))
+          val actionSpec = ActionSpecification(edges=Seq(Edge(edge.v1.node.toString(), edge.v2.node.toString())))
           GameEvent(position, GameAction.BUILD_ROAD, Some(actionSpec))
       case BuildSettlementMove(vertex) =>
         GameEvent(position, GameAction.BUILD_SETTLEMENT, Some(ActionSpecification(vertex = vertex.node.toString())))
@@ -122,7 +122,7 @@ class PlayerContext[GAME <: Inventory[GAME], PLAYER <: Inventory[PLAYER]](val na
       case KnightResult(robber) => 
         val s = robber.steal.getOrElse(null)
         val op = if (s == null) -1 else s.victim
-        GameEvent(position, GameAction.ACTIVATE_KNIGHT, Some(ActionSpecification(hex=robber.robberLocation.toString(), otherPlayerPosition=op)))
+        GameEvent(position, GameAction.ACTIVATE_KNIGHT, Some(ActionSpecification(hex=robber.robberLocation.toString(), otherPlayerPositions = Seq(op))))
       case RoadBuilderMove(road1, road2) => 
         val r2 = road2.getOrElse(road1) // TODO FIX
         val edges = Seq(Edge(road1.v1.node.toString(), road1.v2.node.toString()), Edge(r2.v1.node.toString(), r2.v2.node.toString()))

--- a/src/main/scala/soc/playerRepository/PlayerContext.scala
+++ b/src/main/scala/soc/playerRepository/PlayerContext.scala
@@ -7,50 +7,67 @@ import soc.game.{CatanMove, GameState, MoveResult}
 import soc.game.inventory.Inventory
 import soc.game.inventory.Inventory.PerfectInfo
 import soc.game.player.moveSelector.PossibleMoveSelector
-import soc.protos.game.GameUpdate
+import soc.protos.game.{GameMessage, ActionRequest, GameEvent, GameAction}
 import soc.storage.GameId
 
 import scala.collection.mutable.HashMap
 import scala.concurrent.{Future, Promise}
 import scala.util.Random
+import soc.game.BuildCityMove
+import _root_.soc.protos.game.ActionSpecification
+import soc.game.BuildSettlementMove
+import soc.game.RollResult
+import _root_.soc.protos.game.ActionResult
+import soc.game.MoveRobberAndStealResult
+import soc.game.BuildRoadMove
+import soc.game.BuyDevelopmentCardResult
+import soc.game.KnightResult
+import soc.game.YearOfPlentyMove
+import soc.game.MonopolyResult
+import soc.game.RoadBuilderMove
+import soc.game.PortTradeMove
+import soc.game.EndTurnMove
+import soc.game.DiscardResourcesMove
+import soc.game.InitialPlacementMove
 
 class PlayerContext[GAME <: Inventory[GAME], PLAYER <: Inventory[PLAYER]](val name: String) {
 
   val randomMoveSelector = PossibleMoveSelector.randSelector[PLAYER](new Random)
 
-  private[this] val gameObservers: HashMap[(String, Int), StreamObserver[GameUpdate]] = HashMap.empty
+  private[this] val gameObservers: HashMap[(String, Int), StreamObserver[GameMessage]] = HashMap.empty
   private[this] val expectedResponses: HashMap[(String, Int), Promise[CatanMove]] = HashMap.empty
   private [this] var lastRequest: HashMap[(String, Int), RequestMessage[GAME, PLAYER]] = HashMap.empty
 
   def numGames = gameObservers.size
 
-  def addObserver(gameId: String, position: Int, observer: StreamObserver[GameUpdate]): PlayerContext[GAME, PLAYER] = {
+  def addObserver(gameId: String, position: Int, observer: StreamObserver[GameMessage]): PlayerContext[GAME, PLAYER] = {
     gameObservers.put((gameId, position), observer)
     this
   }
 
   def sendInitialGameState(gameId: GameId, position: Int, state: GameState[PLAYER]): Unit = {
-    val observer: StreamObserver[GameUpdate] = gameObservers.getOrElse((gameId.key, position), throw new Exception(""))
-    //observer.onNext(new GameUpdate(Nil, moveResult.toString, position))
+    val observer: StreamObserver[GameMessage] = gameObservers.getOrElse((gameId.key, position), throw new Exception(""))
+    //observer.onNext(new GameMessage(Nil, moveResult.toString, position))
   }
 
   def sendGameOver(gameId: GameId, position: Int, msg: String) {
-    val observer: StreamObserver[GameUpdate] = gameObservers.getOrElse((gameId.key, position), throw new Exception(""))
-    observer.onNext(GameUpdate(payload = "GAME OVER: " + msg, actionRequestedPlayers = Seq.empty[String]))
+    val observer: StreamObserver[GameMessage] = gameObservers.getOrElse((gameId.key, position), throw new Exception(""))
+    observer.onNext(GameMessage().withEvent(new GameEvent(message = "GAME OVER")))
   }
 
   def updateGameState(gameId: GameId, position: Int, moveResult: MoveResult): Unit = {
-    val observer: StreamObserver[GameUpdate] = gameObservers.getOrElse((gameId.key, position), throw new Exception(""))
-    observer.onNext(new GameUpdate(Nil, moveResult.toString, position))
+    val observer: StreamObserver[GameMessage] = gameObservers.getOrElse((gameId.key, position), throw new Exception(""))
+    var event = getEvent(position, moveResult)
+    observer.onNext(new GameMessage().withEvent(event));
   }
 
   def getMoveResponse(request: RequestMessage[GAME, PLAYER]): Future[CatanMove] = this.synchronized {
     val playerKey = (request.gameId.key, request.playerId)
     lastRequest.put(playerKey, request)
 
-    val observer: StreamObserver[GameUpdate] = gameObservers.getOrElse(playerKey, throw new Exception(""))
+    val observer: StreamObserver[GameMessage] = gameObservers.getOrElse(playerKey, throw new Exception(""))
     // TODO pass state: request.toString
-    observer.onNext(new GameUpdate(Seq(name), request.getClass().toString().split("\\$")(1), request.playerId))
+    //observer.onNext(new GameMessage(Seq(name), request.getClass().toString().split("\\$")(1), request.playerId))
 
     val responsePromise = Promise.apply[CatanMove]()
     expectedResponses.put(playerKey, responsePromise)
@@ -74,6 +91,40 @@ class PlayerContext[GAME <: Inventory[GAME], PLAYER <: Inventory[PLAYER]](val na
       case MoveRequest(gameId, state: GameState[PLAYER], inventory: PerfectInfo, position, _) =>
         randomMoveSelector.turnMove(state, inventory, position)
       case _ =>
+        null
+    }
+  }
+
+  def getEvent(position: Int, moveResult: MoveResult): GameEvent = {
+    moveResult match {
+      case InitialPlacementMove(first, settlement, road) => 
+        null
+      case RollResult(roll) => 
+        GameEvent(position, GameAction.ROLL_DICE, null, Some(ActionResult(roll=roll.number)))
+      case MoveRobberAndStealResult(robberLocation, steal) => 
+        val s = steal.getOrElse(null)
+        GameEvent(position, GameAction.MOVE_ROBBER_AND_STEAL, Some(ActionSpecification(hex=robberLocation.toString(), otherPlayerPosition=s.victim)))
+      case BuildRoadMove(edge) => 
+        null
+      case BuildSettlementMove(vertext) =>
+        null
+      case BuildCityMove(vertex) =>
+        GameEvent(position, GameAction.BUILD_CITY, Some(ActionSpecification(vertex=vertex.node.toString())))
+      case BuyDevelopmentCardResult(card) => 
+        null
+      case KnightResult(robber) => 
+        null
+      case RoadBuilderMove(road1, road2) => 
+        null
+      case YearOfPlentyMove(res1, res2) => 
+        null
+      case MonopolyResult(cardsLost) => 
+        null
+      case PortTradeMove(give, get) => 
+        null
+      case DiscardResourcesMove(resourceSet) => 
+        null
+      case EndTurnMove => 
         null
     }
   }

--- a/src/main/scala/soc/playerRepository/PlayerContext.scala
+++ b/src/main/scala/soc/playerRepository/PlayerContext.scala
@@ -7,7 +7,7 @@ import soc.game.{CatanMove, GameState, MoveResult}
 import soc.game.inventory.Inventory
 import soc.game.inventory.Inventory.PerfectInfo
 import soc.game.player.moveSelector.PossibleMoveSelector
-import soc.protos.game.{GameMessage, ActionRequest, GameEvent, GameAction}
+import soc.protos.game.{GameMessage, ActionRequest, GameEvent, GameAction, Edge, Resource, ResourceTransaction}
 import soc.storage.GameId
 
 import scala.collection.mutable.HashMap
@@ -29,10 +29,14 @@ import soc.game.PortTradeMove
 import soc.game.EndTurnMove
 import soc.game.DiscardResourcesMove
 import soc.game.InitialPlacementMove
+import scala.collection.mutable
+import soc.game.inventory.resources.CatanResourceSet
+import soc.protos.game.ActionRequest.ActionRequestType
 
 class PlayerContext[GAME <: Inventory[GAME], PLAYER <: Inventory[PLAYER]](val name: String) {
 
   val randomMoveSelector = PossibleMoveSelector.randSelector[PLAYER](new Random)
+  val resourceMap = HashMap(("Brick", Resource.CLAY), ("Ore", Resource.STONE), ("Sheep", Resource.SHEEP), ("Wheat", Resource.WHEAT), ("Wood", Resource.WOOD))  
 
   private[this] val gameObservers: HashMap[(String, Int), StreamObserver[GameMessage]] = HashMap.empty
   private[this] val expectedResponses: HashMap[(String, Int), Promise[CatanMove]] = HashMap.empty
@@ -47,7 +51,7 @@ class PlayerContext[GAME <: Inventory[GAME], PLAYER <: Inventory[PLAYER]](val na
 
   def sendInitialGameState(gameId: GameId, position: Int, state: GameState[PLAYER]): Unit = {
     val observer: StreamObserver[GameMessage] = gameObservers.getOrElse((gameId.key, position), throw new Exception(""))
-    //observer.onNext(new GameMessage(Nil, moveResult.toString, position))
+    //observer.onNext(new GameMessage().withRequest(ActionRequest(position, ActionRequestType.ACKNOWLEDGE_START_GAME)))
   }
 
   def sendGameOver(gameId: GameId, position: Int, msg: String) {
@@ -58,23 +62,38 @@ class PlayerContext[GAME <: Inventory[GAME], PLAYER <: Inventory[PLAYER]](val na
   def updateGameState(gameId: GameId, position: Int, moveResult: MoveResult): Unit = {
     val observer: StreamObserver[GameMessage] = gameObservers.getOrElse((gameId.key, position), throw new Exception(""))
     var event = getEvent(position, moveResult)
+    println(event)
     observer.onNext(new GameMessage().withEvent(event));
   }
 
   def getMoveResponse(request: RequestMessage[GAME, PLAYER]): Future[CatanMove] = this.synchronized {
+    println("Move request: " + request.playerId)
     val playerKey = (request.gameId.key, request.playerId)
     lastRequest.put(playerKey, request)
 
     val observer: StreamObserver[GameMessage] = gameObservers.getOrElse(playerKey, throw new Exception(""))
-    // TODO pass state: request.toString
-    //observer.onNext(new GameMessage(Seq(name), request.getClass().toString().split("\\$")(1), request.playerId))
+    // TODO pass state
+    val action = getActionRequestType(request)
+    observer.onNext(new GameMessage().withRequest(ActionRequest(request.playerId, action)))
 
-    val responsePromise = Promise.apply[CatanMove]()
-    expectedResponses.put(playerKey, responsePromise)
-    responsePromise.future
+    request match {
+      case InitialPlacementRequest(gameId, state, inventory: PerfectInfo, position, first, _) =>
+        Future.successful(randomMoveSelector.initialPlacementMove(state, inventory, position)(first))
+      case DiscardCardRequest(gameId, state: GameState[PLAYER], inventory: PerfectInfo, position, _) =>
+        Future.successful(randomMoveSelector.discardCardsMove(state, inventory, position))
+      case MoveRobberRequest(gameId, state: GameState[PLAYER], inventory: PerfectInfo, position, _) =>
+        Future.successful(randomMoveSelector.moveRobberAndStealMove(state, inventory, position))
+      case MoveRequest(gameId, state: GameState[PLAYER], inventory: PerfectInfo, position, _) =>
+        Future.successful((randomMoveSelector.turnMove(state, inventory, position)))
+      case _ =>
+        val responsePromise = Promise.apply[CatanMove]()
+        expectedResponses.put(playerKey, responsePromise)
+        responsePromise.future
+    }
   }
 
   def receiveMove(gameId: String, position: Int, move: CatanMove): Boolean = {
+    println(move)
     expectedResponses.get((gameId, position)).map(_.success(move))
     expectedResponses.remove((gameId, position)).isDefined
   }
@@ -98,35 +117,78 @@ class PlayerContext[GAME <: Inventory[GAME], PLAYER <: Inventory[PLAYER]](val na
   def getEvent(position: Int, moveResult: MoveResult): GameEvent = {
     moveResult match {
       case InitialPlacementMove(first, settlement, road) => 
-        null
+        val actionSpec = ActionSpecification(vertex = settlement.node.toString(), edge = Some(Edge(road.v1.node.toString(), road.v2.node.toString())))
+        GameEvent(position, GameAction.INITIAL_PLACEMENT, Some(actionSpec))
       case RollResult(roll) => 
-        GameEvent(position, GameAction.ROLL_DICE, null, Some(ActionResult(roll=roll.number)))
+        GameEvent(position, GameAction.ROLL_DICE, result = Some(ActionResult(roll=roll.number)))
       case MoveRobberAndStealResult(robberLocation, steal) => 
         val s = steal.getOrElse(null)
-        GameEvent(position, GameAction.MOVE_ROBBER_AND_STEAL, Some(ActionSpecification(hex=robberLocation.toString(), otherPlayerPosition=s.victim)))
+        val op = if (s == null) -1 else s.victim
+        GameEvent(position, GameAction.MOVE_ROBBER_AND_STEAL, Some(ActionSpecification(hex = robberLocation.toString(), otherPlayerPosition = op)))
       case BuildRoadMove(edge) => 
-        null
-      case BuildSettlementMove(vertext) =>
-        null
+          val actionSpec = ActionSpecification(edge=Some(Edge(edge.v1.node.toString(), edge.v2.node.toString())))
+          GameEvent(position, GameAction.BUILD_ROAD, Some(actionSpec))
+      case BuildSettlementMove(vertex) =>
+        GameEvent(position, GameAction.BUILD_SETTLEMENT, Some(ActionSpecification(vertex = vertex.node.toString())))
       case BuildCityMove(vertex) =>
-        GameEvent(position, GameAction.BUILD_CITY, Some(ActionSpecification(vertex=vertex.node.toString())))
+        GameEvent(position, GameAction.BUILD_CITY, Some(ActionSpecification(vertex = vertex.node.toString())))
       case BuyDevelopmentCardResult(card) => 
-        null
+        GameEvent(position, GameAction.BUILD_DEVELOPMENT_CARD)
       case KnightResult(robber) => 
-        null
+        val s = robber.steal.getOrElse(null)
+        val op = if (s == null) -1 else s.victim
+        GameEvent(position, GameAction.ACTIVATE_KNIGHT, Some(ActionSpecification(hex=robber.robberLocation.toString(), otherPlayerPosition=op)))
       case RoadBuilderMove(road1, road2) => 
-        null
+        val r2 = road2.getOrElse(road1) // TODO FIX
+        val edges = Seq(Edge(road1.v1.node.toString(), road1.v2.node.toString()), Edge(r2.v1.node.toString(), r2.v2.node.toString()))
+        GameEvent(position, GameAction.ACTIVATE_ROAD_BUILDING, Some(ActionSpecification(edges = edges)))
       case YearOfPlentyMove(res1, res2) => 
-        null
+        val r1 = resourceMap.getOrElse(res1.name, null)
+        val r2 = resourceMap.getOrElse(res2.name, null)
+        val actionSpec = ActionSpecification(ask=Seq(r1, r2))
+        val result = ActionResult(resourcesTransacted = Map((1, ResourceTransaction(gain = Seq(r1, r2)))))
+        GameEvent(position, GameAction.ACTIVATE_YEAR_OF_PLENTY, Some(actionSpec), Some(result))
       case MonopolyResult(cardsLost) => 
-        null
-      case PortTradeMove(give, get) => 
-        null
-      case DiscardResourcesMove(resourceSet) => 
-        null
+        val transacted = cardsLost.map({case (p, resources) => (p, ResourceTransaction(lose=getResources(resources)))})
+        // TODO: This should also include the resource in the action spec
+        GameEvent(position, GameAction.ACTIVATE_MONOPOLY, result = Some(ActionResult(resourcesTransacted = transacted)))
+      case PortTradeMove(give, get) =>
+        val transacted = Map((position, ResourceTransaction(gain = getResources(get), lose = getResources(give))))
+        GameEvent(position, GameAction.PORT_TRADE, result = Some(ActionResult(resourcesTransacted = transacted)))
+      case DiscardResourcesMove(resourceSet) =>
+          // BROKEN: This should not be bundled by player, for now just defualting to the first player 
+          val first = resourceSet.values.head
+          val transacted = Map((position, ResourceTransaction(lose = getResources(first))))
+          GameEvent(position, GameAction.DISCARD, result = Some(ActionResult(resourcesTransacted = transacted)))
       case EndTurnMove => 
-        null
+        GameEvent(position, GameAction.END_TURN)
     }
+  }
+
+  private def getResources(resourceSet: CatanResourceSet.Resources): Seq[Resource] = {
+    val resources: mutable.ListBuffer[Resource] = mutable.ListBuffer()
+    resourceSet.amountMap.foreach({ case (res, amt) =>
+        for (i <- 0 to amt) {
+          println(res.name)
+          resources += resourceMap.getOrElse(res.name, null)
+        } 
+    })
+    resources.toSeq
+  }
+
+  private def getActionRequestType(request: RequestMessage[GAME, PLAYER]): ActionRequestType = {
+      request match {
+        case InitialPlacementRequest(gameId, playerState, inventory, playerId, first, respondTo) => 
+          ActionRequestType.PLACE_INITIAL_SETTLEMENT
+        case MoveRequest(gameId, playerState, inventory, playerId, respondTo) => 
+          ActionRequestType.BUILD_OR_TRADE_OR_PLAY_OR_PASS
+        case DiscardCardRequest(gameId, playerState, inventory, playerId, respondTo) => 
+          ActionRequestType.DISCARD
+        case MoveRobberRequest(gameId, playerState, inventory, playerId, respondTo) => 
+          // This is just a filler
+          ActionRequestType.ACKNOWLEDGE_PING
+      }
+
   }
 
 //  def getInitialPlacementMove(gameId: GameId, position: Int, inventory: GAME, id: Int, first: Boolean): Future[CatanMove] = {


### PR DESCRIPTION
## What

Creates the protobuff definitions for client and server to request / response pattern.

The server streams `GameMessage`s which are one of `GameEvent` or `ActionRequest`.

The client listens for `ActionRequest` and responds by making a `TakeAction` RPC. This in turn triggers the streaming of a `GameEvent` (which specifies the action taken, including its result), followed by another `ActionRequest`. 

The design focuses on a set of actions that flow through the request and into the response.

Python companion: https://github.com/SOC-Training-Tool/SOC-Python-Client/pull/3